### PR TITLE
feat: implementar rol responsabilidad_salud con vista y recomendaciones

### DIFF
--- a/app/api/v1/endpoints/encuesta_hplp.py
+++ b/app/api/v1/endpoints/encuesta_hplp.py
@@ -23,9 +23,15 @@ from app.schemas.encuesta_hplp import (
     ProgramaGroupAF,
     ResultadosActFisicaResponse,
     RecomendacionesAFResponse,
+    ResponsabilidadSaludItems,
+    ResultadoRespSaludItem,
+    ProgramaGroupRS,
+    ResultadosRespSaludResponse,
+    RecomendacionesRSResponse,
 )
 from app.services.recomendaciones_pp_service import obtener_recomendaciones_pp
 from app.services.recomendaciones_af_service import obtener_recomendaciones_af
+from app.services.recomendaciones_rs_service import obtener_recomendaciones_rs
 from app.models.user import UserRole
 from app.services.encuesta_hplp_service import calcular_puntajes
 from app.repositories import encuesta_hplp_repository as repo
@@ -338,6 +344,87 @@ def recomendaciones_actividad_fisica(
         nombre=current_user.full_name,
         af_nivel=ultimo.af_nivel,
         af_indice=ultimo.af_indice,
+        total_tarjetas=len(tarjetas),
+        tarjetas=[TarjetaRecomendacion(**t) for t in tarjetas],
+    )
+
+
+@router.get("/responsabilidad-salud/resultados", response_model=ResultadosRespSaludResponse)
+def resultados_responsabilidad_salud(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Vista exclusiva para el rol de Responsabilidad en Salud.
+    Devuelve los resultados (ítems 3,9,15,22,28,34,41) de todos los estudiantes
+    que completaron la encuesta, agrupados por programa/facultad.
+    """
+    if current_user.role != UserRole.RESPONSABILIDAD_SALUD:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Solo el profesional de Responsabilidad en Salud puede acceder a esta vista",
+        )
+
+    filas = repo.obtener_resultados_rs_todos(db)
+
+    grupos: dict[str | None, list[ResultadoRespSaludItem]] = {}
+    for encuesta, usuario in filas:
+        item = ResultadoRespSaludItem(
+            encuesta_id=encuesta.id,
+            usuario_id=str(usuario.id),
+            nombre=usuario.full_name,
+            programa=usuario.program,
+            universidad=usuario.university,
+            fecha=encuesta.fecha_respuesta,
+            responsabilidad_salud=ResponsabilidadSaludItems(
+                rs_item_03=encuesta.rs_item_03,
+                rs_item_09=encuesta.rs_item_09,
+                rs_item_15=encuesta.rs_item_15,
+                rs_item_22=encuesta.rs_item_22,
+                rs_item_28=encuesta.rs_item_28,
+                rs_item_34=encuesta.rs_item_34,
+                rs_item_41=encuesta.rs_item_41,
+                rs_indice=encuesta.rs_indice,
+                rs_nivel=encuesta.rs_nivel,
+            ),
+        )
+        grupos.setdefault(usuario.program, []).append(item)
+
+    grupos_list = [
+        ProgramaGroupRS(programa=prog, total=len(estudiantes), estudiantes=estudiantes)
+        for prog, estudiantes in grupos.items()
+    ]
+
+    return ResultadosRespSaludResponse(
+        total_estudiantes=len(filas),
+        grupos=grupos_list,
+    )
+
+
+@router.get("/recomendaciones/responsabilidad-salud", response_model=RecomendacionesRSResponse)
+def recomendaciones_responsabilidad_salud(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Devuelve el plan de recomendaciones de Responsabilidad en Salud para el usuario autenticado.
+    Solo genera tarjetas para niveles POBRE y MODERADO (el profesional así lo indicó).
+    Requiere haber completado la encuesta.
+    """
+    ultimo = repo.obtener_ultimo(db, current_user.id)
+    if not ultimo:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="El usuario aún no ha completado la encuesta",
+        )
+
+    tarjetas = obtener_recomendaciones_rs(ultimo)
+
+    return RecomendacionesRSResponse(
+        usuario_id=str(current_user.id),
+        nombre=current_user.full_name,
+        rs_nivel=ultimo.rs_nivel,
+        rs_indice=ultimo.rs_indice,
         total_tarjetas=len(tarjetas),
         tarjetas=[TarjetaRecomendacion(**t) for t in tarjetas],
     )

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -13,6 +13,7 @@ class UserRole(str, enum.Enum):
     ADMIN = "admin"
     CAPELLAN = "capellan"
     ACTIVIDAD_FISICA = "actividad_fisica"
+    RESPONSABILIDAD_SALUD = "responsabilidad_salud"
 
 
 class User(Base):

--- a/app/repositories/encuesta_hplp_repository.py
+++ b/app/repositories/encuesta_hplp_repository.py
@@ -105,6 +105,28 @@ def eliminar(db: Session, encuesta_id: int) -> bool:
     return True
 
 
+def obtener_resultados_rs_todos(db: Session) -> list[tuple[EncuestaHplp, User]]:
+    """Retorna la encuesta más reciente de cada usuario (para Responsabilidad en Salud)."""
+    from sqlalchemy import func
+
+    subq = (
+        db.query(
+            EncuestaHplp.usuario_id,
+            func.max(EncuestaHplp.id).label("ultimo_id"),
+        )
+        .group_by(EncuestaHplp.usuario_id)
+        .subquery()
+    )
+
+    return (
+        db.query(EncuestaHplp, User)
+        .join(subq, EncuestaHplp.id == subq.c.ultimo_id)
+        .join(User, User.id == EncuestaHplp.usuario_id)
+        .order_by(User.program, User.full_name)
+        .all()
+    )
+
+
 def obtener_resultados_af_todos(db: Session) -> list[tuple[EncuestaHplp, User]]:
     """Retorna la encuesta más reciente de cada usuario junto con sus datos de perfil (para Actividad Física)."""
     from sqlalchemy import func

--- a/app/schemas/encuesta_hplp.py
+++ b/app/schemas/encuesta_hplp.py
@@ -219,3 +219,47 @@ class RecomendacionesAFResponse(BaseModel):
     af_indice: float
     total_tarjetas: int
     tarjetas: List[TarjetaRecomendacion]
+
+
+# ── Vista Responsabilidad en Salud ────────────────────────────────────────────
+
+class ResponsabilidadSaludItems(BaseModel):
+    rs_item_03: int
+    rs_item_09: int
+    rs_item_15: int
+    rs_item_22: int
+    rs_item_28: int
+    rs_item_34: int
+    rs_item_41: int
+    rs_indice: float
+    rs_nivel: str
+
+
+class ResultadoRespSaludItem(BaseModel):
+    encuesta_id: int
+    usuario_id: str
+    nombre: str
+    programa: str | None
+    universidad: str | None
+    fecha: datetime
+    responsabilidad_salud: ResponsabilidadSaludItems
+
+
+class ProgramaGroupRS(BaseModel):
+    programa: str | None
+    total: int
+    estudiantes: List[ResultadoRespSaludItem]
+
+
+class ResultadosRespSaludResponse(BaseModel):
+    total_estudiantes: int
+    grupos: List[ProgramaGroupRS]
+
+
+class RecomendacionesRSResponse(BaseModel):
+    usuario_id: str
+    nombre: str | None
+    rs_nivel: str
+    rs_indice: float
+    total_tarjetas: int
+    tarjetas: List[TarjetaRecomendacion]

--- a/app/services/recomendaciones_rs_service.py
+++ b/app/services/recomendaciones_rs_service.py
@@ -1,0 +1,133 @@
+"""
+Servicio de recomendaciones de Responsabilidad en Salud.
+Tabla estática de 14 tarjetas (7 preguntas × 2 niveles: POBRE y MODERADO).
+BUENO y EXCELENTE no reciben recomendación (el profesional así lo indicó).
+"""
+from app.models.encuesta_hplp import EncuestaHplp
+
+
+def puntaje_a_nivel(valor: int) -> str:
+    return {1: "POBRE", 2: "MODERADO", 3: "BUENO", 4: "EXCELENTE"}[valor]
+
+
+PREGUNTAS = {
+    3:  "Informar a los profesionales de la salud cualquier señal inusual o síntoma extraño en tu salud o cuerpo.",
+    9:  "Procurar mantenerte informado acerca del mejoramiento de la salud.",
+    15: "Hacer preguntas a los profesionales de la salud para poder entender sus instrucciones.",
+    22: "Buscar una segunda opinión cuando tengas dudas de las recomendaciones de tu proveedor de servicios de salud.",
+    28: "Dialogar tus puntos de vista acerca de la salud con los profesionales en este campo.",
+    34: "Examinar mensualmente tu cuerpo para detectar cambios físicos o señales diferentes en él.",
+    41: "Pedir orientación de los profesionales de la salud sobre cómo mantenerte en buen estado de salud.",
+}
+
+ITEM_FIELDS = {
+    3:  "rs_item_03",
+    9:  "rs_item_09",
+    15: "rs_item_15",
+    22: "rs_item_22",
+    28: "rs_item_28",
+    34: "rs_item_34",
+    41: "rs_item_41",
+}
+
+# La misma técnica aplica para POBRE y MODERADO en cada pregunta.
+_REC = {
+    3: {
+        "tecnica": "Bitácora de síntomas",
+        "objetivo": "Desarrollar la capacidad de detectar signos y síntomas de alarma inusuales y consultar a tiempo.",
+        "instrucciones": [
+            "Toma 1 minuto cada noche para realizar un escaneo mental de pies a cabeza y determinar si hubo una señal inusual durante el día (algún dolor, fatiga, cambio).",
+            "Registra el síntoma en tu diario de señales de alerta de la app: describe el síntoma, la duración y la intensidad.",
+            "Ubica los síntomas en el semáforo de síntomas para definir si requieres atención inmediata: Verde (estado óptimo), Amarillo/Naranja (alerta temprana) o Rojo (urgencia).",
+            "Lleva la bitácora de escaneo a tu consulta médica e informa al médico los registros que hiciste.",
+        ],
+    },
+    9: {
+        "tecnica": "Alfabetización en salud",
+        "objetivo": "Incrementar el conocimiento sobre estilo de vida saludable.",
+        "instrucciones": [
+            "Cada semana escoge un tema sobre estilo de vida saludable que desees aprender (nutrición, ejercicio, sueño, etc.).",
+            "Busca información sobre el tema en fuentes oficiales (OMS, revistas científicas, boletines informativos). Puedes leer un artículo, aprender una receta saludable o realizar una rutina de ejercicio nueva.",
+            "Pon en práctica lo aprendido y regístralo en la app.",
+        ],
+    },
+    15: {
+        "tecnica": "Pregunta – Respuesta – Confirmación",
+        "objetivo": "Comprender de forma clara las recomendaciones e indicaciones dadas por el profesional de salud para garantizar un adecuado cumplimiento del tratamiento.",
+        "instrucciones": [
+            "Anota las dudas que tengas antes de ir a tu consulta médica para no olvidarlas cuando estés frente al médico. Puedes guiarte de las preguntas inteligentes que sugiere la app.",
+            "Utiliza la técnica de feedback: explícale a tu médico lo que entendiste de las indicaciones para que pueda corregir errores.",
+            "No te retires de la consulta hasta tener todas las dudas claras y las indicaciones entendidas.",
+        ],
+    },
+    22: {
+        "tecnica": "Triangulación de criterio médico",
+        "objetivo": "Empoderar al usuario en la seguridad sobre su tratamiento y la certeza en la toma de decisiones.",
+        "instrucciones": [
+            "Cuando tengas dudas sobre las recomendaciones médicas, no tengas miedo de preguntar; si es necesario, solicita evidencia científica.",
+            "Si aún tienes dudas o no estás seguro con las recomendaciones, solicita una segunda cita con otro profesional diferente y exprésale tu caso y tus dudas.",
+            "Contrasta ambas informaciones para poder tomar una decisión final sobre tu tratamiento.",
+        ],
+    },
+    28: {
+        "tecnica": "Negociación conductual en la consulta médica",
+        "objetivo": "Fomentar la integración de las creencias personales con las recomendaciones médicas.",
+        "instrucciones": [
+            "Identifica creencias o hábitos que no van acorde con las sugerencias médicas.",
+            "Expresa tu punto de vista o creencia al médico de forma respetuosa.",
+            "Llega a un acuerdo con el médico y diseña un plan de tratamiento en que converjan ambos puntos de vista, que sea realista y ajustable a tu vida.",
+        ],
+    },
+    34: {
+        "tecnica": "Autoexamen corporal",
+        "objetivo": "Crear el hábito de realizar los autoexámenes para detectar alguna alteración a tiempo.",
+        "instrucciones": [
+            "Configura en la app una alarma mensual para realizarte el autoexamen (de mama en mujeres, testicular en hombres).",
+            "Sigue los pasos de la imagen o del video para realizarte el autoexamen.",
+            "Reporta en la app si encuentras un hallazgo anormal o si no encuentras cambios.",
+            "Si encuentras algo fuera de lo normal, consulta al médico y reporta el hallazgo.",
+        ],
+    },
+    41: {
+        "tecnica": "Control médico preventivo",
+        "objetivo": "Promover la salud antes de que llegue un proceso de enfermedad.",
+        "instrucciones": [
+            "Agenda una cita de revisión y promoción de la salud sin necesidad de tener algún signo de enfermedad.",
+            "Solicita un análisis de tu estilo de vida para detectar los factores de riesgo a desarrollar enfermedades.",
+            "Trabaja en los factores de riesgo detectados haciendo cambios en tu estilo de vida que busquen disminuir el riesgo de desarrollar una enfermedad.",
+        ],
+    },
+}
+
+RECOMENDACIONES: dict[int, dict[str, dict]] = {
+    num_q: {"POBRE": rec, "MODERADO": rec}
+    for num_q, rec in _REC.items()
+}
+
+NIVELES_CON_RECOMENDACION = {"POBRE", "MODERADO"}
+PRIORIDAD_NIVEL = {"POBRE": 0, "MODERADO": 1}
+
+
+def obtener_recomendaciones_rs(encuesta: EncuestaHplp) -> list[dict]:
+    """
+    Devuelve tarjetas de recomendación de Responsabilidad en Salud.
+    Solo para POBRE y MODERADO. Orden: POBRE → MODERADO.
+    """
+    tarjetas = []
+    for num_q, campo in ITEM_FIELDS.items():
+        valor = getattr(encuesta, campo)
+        nivel = puntaje_a_nivel(valor)
+        if nivel not in NIVELES_CON_RECOMENDACION:
+            continue
+        rec = RECOMENDACIONES[num_q][nivel]
+        tarjetas.append({
+            "pregunta_num": num_q,
+            "pregunta_texto": PREGUNTAS[num_q],
+            "nivel": nivel,
+            "puntaje": valor,
+            "tecnica": rec["tecnica"],
+            "objetivo": rec["objetivo"],
+            "instrucciones": rec["instrucciones"],
+        })
+    tarjetas.sort(key=lambda t: PRIORIDAD_NIVEL[t["nivel"]])
+    return tarjetas

--- a/crear_resp_salud.py
+++ b/crear_resp_salud.py
@@ -1,0 +1,27 @@
+from app.db.session import engine
+from app.core.security import hash_password
+from sqlalchemy import text
+
+with engine.connect() as conn:
+    existe = conn.execute(
+        text("SELECT id FROM users WHERE email = 'respsalud@vitalis.com'")
+    ).fetchone()
+
+    if existe:
+        print("El usuario de Responsabilidad en Salud ya existe, nada que hacer.")
+    else:
+        conn.execute(
+            text("""
+                INSERT INTO users (id, email, password_hash, full_name, role,
+                                   is_active, is_verified, total_xp, current_level,
+                                   streak_days, created_at, updated_at)
+                VALUES (gen_random_uuid(), 'respsalud@vitalis.com', :pwd,
+                        'Profesional Responsabilidad en Salud', 'responsabilidad_salud',
+                        true, true, 0, 1, 0, now(), now())
+            """),
+            {"pwd": hash_password("RespSalud1234")},
+        )
+        conn.commit()
+        print("Usuario Responsabilidad en Salud creado")
+        print("Email:    respsalud@vitalis.com")
+        print("Password: RespSalud1234")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,6 +131,34 @@ def act_fisica_headers(client, act_fisica_user):
     return {"Authorization": f"Bearer {token}"}
 
 
+@pytest.fixture()
+def resp_salud_user(client):
+    payload = {
+        "full_name": "Resp Salud Test",
+        "email": "respsalud@vitalis.com",
+        "password": "password123",
+        "confirm_password": "password123",
+    }
+    client.post("/api/v1/auth/register", json=payload)
+    db = TestingSessionLocal()
+    from app.models.user import User, UserRole
+    user = db.query(User).filter(User.email == payload["email"]).first()
+    user.role = UserRole.RESPONSABILIDAD_SALUD
+    db.commit()
+    db.close()
+    return payload
+
+
+@pytest.fixture()
+def resp_salud_headers(client, resp_salud_user):
+    res = client.post(
+        "/api/v1/auth/login",
+        json={"email": resp_salud_user["email"], "password": resp_salud_user["password"]},
+    )
+    token = res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
 ENCUESTA_PAYLOAD = {
     "ri_item_01": 3, "ri_item_07": 2, "ri_item_13": 4, "ri_item_20": 1,
     "ri_item_26": 3, "ri_item_32": 2, "ri_item_38": 4, "ri_item_45": 3, "ri_item_50": 2,

--- a/tests/integration/test_encuesta.py
+++ b/tests/integration/test_encuesta.py
@@ -202,3 +202,82 @@ def test_af_recomendaciones_ok(client, auth_headers):
 def test_af_recomendaciones_sin_auth(client):
     res = client.get(AF_REC_URL)
     assert res.status_code == 401
+
+
+# ── Tests Responsabilidad en Salud ───────────────────────────────────────────
+
+RS_URL = f"{ENCUESTA_URL}/responsabilidad-salud/resultados"
+RS_REC_URL = f"{ENCUESTA_URL}/recomendaciones/responsabilidad-salud"
+
+
+def test_rs_sin_auth(client):
+    res = client.get(RS_URL)
+    assert res.status_code == 401
+
+
+def test_rs_acceso_denegado_sin_rol(client, auth_headers):
+    res = client.get(RS_URL, headers=auth_headers)
+    assert res.status_code == 403
+
+
+def test_rs_estructura_respuesta(client, resp_salud_headers):
+    res = client.get(RS_URL, headers=resp_salud_headers)
+    assert res.status_code == 200
+    data = res.json()
+    assert "total_estudiantes" in data
+    assert "grupos" in data
+    assert isinstance(data["grupos"], list)
+
+
+def test_rs_con_encuestas(client, auth_headers, resp_salud_headers):
+    client.post(ENCUESTA_URL, json=ENCUESTA_PAYLOAD, headers=auth_headers)
+    res = client.get(RS_URL, headers=resp_salud_headers)
+    assert res.status_code == 200
+    data = res.json()
+    assert data["total_estudiantes"] >= 1
+    grupo = data["grupos"][0]
+    assert "programa" in grupo
+    assert "total" in grupo
+    assert "estudiantes" in grupo
+    rs = grupo["estudiantes"][0]["responsabilidad_salud"]
+    for campo in [
+        "rs_item_03", "rs_item_09", "rs_item_15", "rs_item_22",
+        "rs_item_28", "rs_item_34", "rs_item_41",
+        "rs_indice", "rs_nivel",
+    ]:
+        assert campo in rs
+
+
+def test_rs_recomendaciones_sin_encuesta(client, auth_headers):
+    res = client.get(RS_REC_URL, headers=auth_headers)
+    assert res.status_code == 404
+
+
+def test_rs_recomendaciones_ok(client, auth_headers):
+    client.post(ENCUESTA_URL, json=ENCUESTA_PAYLOAD, headers=auth_headers)
+    res = client.get(RS_REC_URL, headers=auth_headers)
+    assert res.status_code == 200
+    data = res.json()
+    assert "rs_nivel" in data
+    assert "rs_indice" in data
+    assert "total_tarjetas" in data
+    assert "tarjetas" in data
+    assert isinstance(data["tarjetas"], list)
+    if data["tarjetas"]:
+        t = data["tarjetas"][0]
+        for campo in ["pregunta_num", "pregunta_texto", "nivel", "puntaje", "tecnica", "objetivo", "instrucciones"]:
+            assert campo in t
+
+
+def test_rs_recomendaciones_solo_pobre_moderado(client, auth_headers):
+    """Preguntas con puntaje BUENO (3) o EXCELENTE (4) no deben generar tarjeta."""
+    client.post(ENCUESTA_URL, json=ENCUESTA_PAYLOAD, headers=auth_headers)
+    res = client.get(RS_REC_URL, headers=auth_headers)
+    data = res.json()
+    for t in data["tarjetas"]:
+        assert t["nivel"] in ("POBRE", "MODERADO"), f"Nivel inesperado: {t['nivel']}"
+
+
+def test_rs_recomendaciones_sin_auth(client):
+    res = client.get(RS_REC_URL)
+    assert res.status_code == 401


### PR DESCRIPTION
- Agrega UserRole.RESPONSABILIDAD_SALUD al enum de roles
- Añade schemas ResponsabilidadSaludItems, ResultadosRespSaludResponse y RecomendacionesRSResponse
- Crea repositorio obtener_resultados_rs_todos (encuesta más reciente por usuario)
- Crea servicio recomendaciones_rs_service con 14 tarjetas estáticas (7 preguntas × POBRE y MODERADO) solo POBRE y MODERADO reciben recomendación; BUENO y EXCELENTE no generan tarjeta
- Endpoints: GET /encuesta/responsabilidad-salud/resultados (rol exclusivo) GET /encuesta/recomendaciones/responsabilidad-salud (usuario autenticado)
- Tests de integración: 8 casos cubriendo auth, acceso por rol, estructura y filtro de niveles
- Script crear_resp_salud.py para insertar el usuario profesional en producción